### PR TITLE
Fix polybar when one monitor but no primary

### DIFF
--- a/config/polybar/launch.sh
+++ b/config/polybar/launch.sh
@@ -12,6 +12,8 @@ MONITOR_EXTRA=$(echo "$MONITORS" | grep -v "primary" | cut -d":" -f1 || true)
 
 # Start main polybar with tray
 MONITOR=${MONITOR_PRIMARY:-${MONITOR_EXTRA%% *}} MOD_RIGHT="systray microphone pulseaudio memory cpu filesystem battery wlan eth date" polybar main &
-for m in $MONITOR_EXTRA; do
+[[ $(wc -l <<<"$MONITORS") > 1 ]] && {
+  for m in $MONITOR_EXTRA; do
     MONITOR=$m MOD_RIGHT="microphone pulseaudio memory cpu filesystem battery wlan eth date" polybar main &
-done
+  done
+}


### PR DESCRIPTION
On a baremetal workstation with only one monitor on DVI port, `polybar --list-monitors` display only one line, e.g. :
`DVI-I-1: 1920x1080+0+0`

Then two poybars was displayed (`$MONITOR_PRIMARY` and `$MONITOR_EXTRA` are empty)